### PR TITLE
Add support for variable-length return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ FuncFind is a Go library for discovering functions by their return types using s
 
 ## Features
 
-- **Type-based function discovery**: Find all functions that return a specific type
+- **Type-based function discovery**: Find all functions that return specific type(s)
 - **Lazy evaluation**: Uses Go 1.23+ iterators for memory-efficient traversal
-- **Standard library compatible**: Works with any Go package, including the standard library
-- **Exact matching**: Finds functions with exactly one return value of the specified type
+- **Flexible matching**: Finds functions matching an exact sequence of return types
 
 ## Installation
 
@@ -41,17 +40,22 @@ func main() {
     for fn := range functions {
         fmt.Println(fn.Name())
     }
+    
+    // Find all functions in the fmt package that return (int, error)
+    functions, err = funcfind.Returning("fmt", "int", "error")
+    if err != nil {
+        panic(err)
+    }
+    
+    for fn := range functions {
+        fmt.Printf("%s returns (int, error)\n", fn.Name())
+    }
 }
 ```
 
-## How It Works
-
-FuncFind uses Go's `golang.org/x/tools/go/packages` to load package information and `go/types` for type analysis. The process:
-
 ## Limitations
 
-- Only finds functions with exactly **one** return value.
-  - It's possible to extend to arbitrary number of return values later.
+- Functions must match the exact number and order of return types specified
 - Type matching is done by string comparison of type representations
 - Requires the target package to be accessible and compilable
 - Does not find unexported functions in external packages

--- a/pkg/funcfind/doc.go
+++ b/pkg/funcfind/doc.go
@@ -11,6 +11,7 @@ the structure of Go codebases.
 # Key Features
 
   - Type-based function discovery using string matching
+  - Support for functions with variable-length return types
   - Lazy evaluation through Go 1.23+ iterators
   - Support for any accessible Go package
   - Memory-efficient processing of large codebases
@@ -18,8 +19,9 @@ the structure of Go codebases.
 
 # Usage Patterns
 
-The primary function is Returning, which takes a package path and a return type string:
+The primary function is Returning, which takes a package path and one or more return type strings:
 
+	// Find functions returning a single error
 	functions, err := funcfind.Returning("fmt", "error")
 	if err != nil {
 		return err
@@ -29,15 +31,26 @@ The primary function is Returning, which takes a package path and a return type 
 		fmt.Printf("Function %s returns error\n", fn.Name())
 	}
 
+	// Find functions returning (int, error)
+	functions, err = funcfind.Returning("fmt", "int", "error")
+	if err != nil {
+		return err
+	}
+
+	for fn := range functions {
+		fmt.Printf("Function %s returns (int, error)\n", fn.Name())
+	}
+
 # Type Matching
 
 Function signatures are matched by comparing the string representation of their return types.
-Only functions with exactly one return value are considered. For example:
+Functions must match the exact number and order of return types specified. For example:
 
-  - func() error          ✓ matches "error"
-  - func() (error, bool)  ✗ multiple returns
-  - func()                ✗ no returns
-  - func() string         ✗ different type
+  - func FnName() error            // ✓ matches Returning(pkg, "error")
+  - func FnName1() (int, error)    // ✓ matches Returning(pkg, "int", "error")
+  - func FnName2() (error, int)    // ✗ wrong order for Returning(pkg, "int", "error")
+  - func FnName5()                 // ✓ matches Returning(pkg)
+  - func FnName4() string          // ✗ different type for Returning(pkg, "error")
 
 # Performance Considerations
 
@@ -54,7 +67,7 @@ The iterator pattern allows for efficient memory usage and early termination:
 
   - Only exported functions are found in external packages
   - Package must be accessible and compilable
-  - Type matching is exact string comparison
+  - Type matching is string comparison, order matters
   - No support for interface satisfaction matching
 
 # Error Handling
@@ -63,7 +76,5 @@ Errors are returned when:
   - Package cannot be loaded (e.g., doesn't exist, compilation errors)
   - Package path is malformed
   - Module resolution fails
-
-All errors are wrapped with context to aid debugging.
 */
 package funcfind

--- a/pkg/funcfind/func_find.go
+++ b/pkg/funcfind/func_find.go
@@ -25,18 +25,15 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// Returning finds all functions in the specified Go package that return exactly one value
-// of the provided returnType.
+// Returning finds all functions in the specified Go package that return the provided
+// returnTypes.
 //
 // The pkgPath parameter should be a valid Go package path (e.g., "fmt", "encoding/json",
-// "github.com/user/repo/pkg"). The returnType parameter should be the string representation
-// of the desired return type (e.g., "error", "string", "github.com/user/repo.CustomType").
+// "github.com/user/repo/pkg"). The returnTypes parameter should be the string representation
+// of the desired return types (e.g., "error", "string", "github.com/user/repo.CustomType").
 //
-// Returns an iterator over all matching functions, allowing for lazy evaluation and early
-// termination. If package loading fails, returns a non-nil error.
-//
-// Only functions with exactly one return value are considered. Functions with zero return
-// values or multiple return values are excluded from results.
+// Returns an iterator over all matching functions.
+// Should package loading fail, returns a non-nil error.
 //
 // Example:
 //
@@ -49,7 +46,7 @@ import (
 //	for fn := range functions {
 //		fmt.Printf("Found: %s\n", fn.Name())
 //	}
-func Returning(pkgPath string, returnType string) (iter.Seq[*types.Func], error) {
+func Returning(pkgPath string, returnTypes ...string) (iter.Seq[*types.Func], error) {
 	pkgs, err := packages.Load(
 		&packages.Config{
 			Mode: packages.NeedTypes | packages.NeedTypesInfo,
@@ -60,18 +57,18 @@ func Returning(pkgPath string, returnType string) (iter.Seq[*types.Func], error)
 		return nil, fmt.Errorf("load package %s: %w", pkgPath, err)
 	}
 
-	return scanPkgForFuncs(pkgs, returnType), nil
+	return scanPkgForFuncs(pkgs, returnTypes), nil
 }
 
-// scanPkgForFuncs discovers all functions in the loaded pkgs package that return returnType and only returnType.
-func scanPkgForFuncs(pkgs []*packages.Package, returnType string) iter.Seq[*types.Func] {
+// scanPkgForFuncs discovers all functions in the loaded pkgs package that return exactly returnTypes.
+func scanPkgForFuncs(pkgs []*packages.Package, returnTypes []string) iter.Seq[*types.Func] {
 	return func(yield func(*types.Func) bool) {
 		for _, pkg := range pkgs {
 			scope := pkg.Types.Scope()
 			for _, name := range scope.Names() {
 				obj := scope.Lookup(name)
 				if fn, ok := obj.(*types.Func); ok {
-					if shouldYield(fn, returnType) && !yield(fn) {
+					if shouldYield(fn, returnTypes) && !yield(fn) {
 						return
 					}
 				}
@@ -80,13 +77,22 @@ func scanPkgForFuncs(pkgs []*packages.Package, returnType string) iter.Seq[*type
 	}
 }
 
-func shouldYield(fn *types.Func, returnType string) bool {
-	results := fn.Signature().Results()
-	if results.Len() != 1 {
+func shouldYield(fn *types.Func, returnTypes []string) bool {
+	if !fn.Exported() {
 		return false
 	}
 
-	rType := results.At(0).Type().String()
+	results := fn.Signature().Results()
+	if results.Len() != len(returnTypes) {
+		return false
+	}
 
-	return rType == returnType
+	for i := range results.Len() {
+		rType := results.At(i).Type().String()
+		if rType != returnTypes[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/funcfind/func_find_test.go
+++ b/pkg/funcfind/func_find_test.go
@@ -2,8 +2,8 @@ package funcfind
 
 import (
 	"go/types"
-	"iter"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,26 +13,57 @@ import (
 func TestReturning(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name       string
-		pkgPath    string
-		returnType string
-		verify     func(tb testing.TB, fns iter.Seq[*types.Func])
-		wantErr    error
+		name        string
+		pkgPath     string
+		returnTypes []string
+		verify      func(tb testing.TB, fns []*types.Func)
+		wantErr     error
 	}{
 		{
-			name:       "Spot check fmt functions for functions that return err",
-			pkgPath:    "fmt",
-			returnType: "error",
-			verify: func(tb testing.TB, s iter.Seq[*types.Func]) {
+			name:        "Spot check fmt functions for functions that return err",
+			pkgPath:     "fmt",
+			returnTypes: []string{"error"},
+			verify: func(tb testing.TB, found []*types.Func) {
 				tb.Helper()
-				found := slices.Collect(s)
-				fnNames := make([]string, 0, len(found))
-				for _, f := range found {
-					fnNames = append(fnNames, f.Name())
-				}
+				fnNames := fnNamesFromTypes(found)
 				assert.Contains(t, fnNames, "Errorf")
 				assert.NotContains(t, fnNames, "Printf")
 				assert.NotContains(t, fnNames, "Sprint")
+			},
+		},
+		{
+			name:        "Find some functions that return multiple values",
+			pkgPath:     "fmt",
+			returnTypes: []string{"int", "error"},
+			verify: func(tb testing.TB, found []*types.Func) {
+				tb.Helper()
+				fnNames := fnNamesFromTypes(found)
+				assert.Contains(t, fnNames, "Fprintf")
+				assert.Contains(t, fnNames, "Fprintln")
+				assert.Contains(t, fnNames, "Print")
+				assert.NotContains(t, fnNames, "Errorf")
+			},
+		},
+		{
+			name:        "Finds no-return functions",
+			pkgPath:     "os",
+			returnTypes: []string{},
+			verify: func(tb testing.TB, found []*types.Func) {
+				tb.Helper()
+				fnNames := fnNamesFromTypes(found)
+				assert.Contains(t, fnNames, "Exit")
+			},
+		},
+		{
+			name:    "No matching functions",
+			pkgPath: "fmt",
+			// order of error, string is chosen because
+			// the standard lib always returns error last
+			returnTypes: []string{"error", "string"},
+			verify: func(tb testing.TB, found []*types.Func) {
+				tb.Helper()
+				fnNames := fnNamesFromTypes(found)
+				assert.Empty(tb, fnNames)
 			},
 		},
 	}
@@ -40,9 +71,28 @@ func TestReturning(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := Returning(tt.pkgPath, tt.returnType)
+			gotIter, err := Returning(tt.pkgPath, tt.returnTypes...)
+			got := slices.Collect(gotIter)
 			require.ErrorIs(t, err, tt.wantErr)
 			tt.verify(t, got)
+			assertAllExportedFns(t, got)
 		})
 	}
+}
+
+func assertAllExportedFns(tb testing.TB, fns []*types.Func) {
+	tb.Helper()
+
+	for _, fn := range fns {
+		firstChar := fn.Name()[0:1]
+		assert.Equal(tb, strings.ToUpper(firstChar), firstChar, "No unexported functions should be present.")
+	}
+}
+
+func fnNamesFromTypes(fns []*types.Func) []string {
+	fnNames := make([]string, 0, len(fns))
+	for _, f := range fns {
+		fnNames = append(fnNames, f.Name())
+	}
+	return fnNames
 }


### PR DESCRIPTION
- Update Returning() to accept variadic returnTypes parameter
- Tests for single, multiple, and zero return types
- Update documentation to reflect changes
- Add export filtering to only return exported functions